### PR TITLE
Support Vendor Media Types

### DIFF
--- a/lib/hypertemplate/builder/base.rb
+++ b/lib/hypertemplate/builder/base.rb
@@ -7,6 +7,14 @@ module Hypertemplate
 
       class << self
         
+        def media_types
+          @media_types
+        end
+
+        def extend_media_types(media_types)
+          @media_types.push(*media_types)
+        end
+
         def build_dsl(obj, options = {}, &block)
           recipe = block_given? ? block : options.delete(:recipe)
           raise Hypertemplate::BuilderError.new("Recipe required to build representation.") unless recipe.respond_to?(:call)

--- a/lib/hypertemplate/builder/json.rb
+++ b/lib/hypertemplate/builder/json.rb
@@ -2,9 +2,7 @@ module Hypertemplate
   module Builder
     class Json < Hypertemplate::Builder::Base
       
-      def self.media_types
-        ["application/json"]
-      end
+      @media_types = ["application/json"]
 
       attr_reader :raw
 

--- a/lib/hypertemplate/builder/xml.rb
+++ b/lib/hypertemplate/builder/xml.rb
@@ -2,9 +2,7 @@ module Hypertemplate
   module Builder
     class Xml < Hypertemplate::Builder::Base
 
-      def self.media_types
-        ["application/xml", "text/xml"]
-      end
+      @media_types = ["application/xml", "text/xml"]
 
       attr_reader :raw
 


### PR DESCRIPTION
This commit allows a call such as:

Hypertemplate::Builder::Xml.extend_media_types("application/vnd.company.model+xml")

and

Hypertemplate::Builder::Json.extend_media_types(["application/vnd.company.model+json","application/vnd.company.other_model+xml"])

Discussion on vendor media types:
http://blog.steveklabnik.com/2011/08/07/some-people-understand-rest-and-http.html

GitHub does this here:
http://developer.github.com/v3/mimes/
