### PR TITLE
Add a way to cache certain parts of a document

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source :rubygems
 # Main dependencies
 gem "json_pure", :require => "json/pure"
 gem "nokogiri"
-gem 'yajl-ruby', require: 'yajl'
 
 group :development, :test do
   gem "ruby-debug"  , :platforms => [:mri_18]

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source :rubygems
 # Main dependencies
 gem "json_pure", :require => "json/pure"
 gem "nokogiri"
+gem 'yajl-ruby', require: 'yajl'
 
 group :development, :test do
   gem "ruby-debug"  , :platforms => [:mri_18]

--- a/lib/hypertemplate/builder.rb
+++ b/lib/hypertemplate/builder.rb
@@ -2,6 +2,7 @@ module Hypertemplate
   module Builder
     require "hypertemplate/builder/base"
     require "hypertemplate/builder/values"
+    require "hypertemplate/builder/cache"
     require "hypertemplate/builder/json"
     require "hypertemplate/builder/xml"
 

--- a/lib/hypertemplate/builder/base.rb
+++ b/lib/hypertemplate/builder/base.rb
@@ -6,7 +6,14 @@ module Hypertemplate
       undef_method :id if respond_to?(:id)
 
       class << self
-        
+        def cache
+          @cache
+        end
+
+        def cache=(cache)
+          @cache = cache
+        end
+
         def media_types
           @media_types
         end
@@ -95,6 +102,12 @@ module Hypertemplate
       def ns(*args, &block)
         values do |v|
           v.send(:[], *args, &block)
+        end
+      end
+
+      def cache(key)
+        Cache.new(key, self) do |cache|
+          yield cache
         end
       end
 

--- a/lib/hypertemplate/builder/cache.rb
+++ b/lib/hypertemplate/builder/cache.rb
@@ -1,0 +1,49 @@
+module Hypertemplate
+  module Builder
+    class Cache #< BasicObject
+      attr_accessor :builder
+
+      def initialize(key, builder, &block)
+        @key = key
+        @builder = builder
+
+        if cached?
+          raw = cache.read(cache_key)
+
+          if builder.class == Xml
+            data = Nokogiri::XML(raw)
+          else
+            data = MultiJson.decode(raw)
+          end
+        else
+          _builder = builder.class.new({})
+          yield _builder
+          data = _builder.raw
+
+          cache.write(cache_key, _builder.representation)
+        end
+
+        if current = builder.instance_variable_get('@current') # JSON
+          current.merge!(data)
+        else # XML
+          parent = builder.instance_variable_get('@parent')
+          data.root.children.each do |element|
+            element.parent = parent
+          end
+        end
+      end
+
+      def cached?
+        cache.exist?(cache_key)
+      end
+
+      def cache
+        Hypertemplate::Builder::Base.cache
+      end
+
+      def cache_key
+        @_generated_key ||= "#{@key}_#{builder.class.to_s.split('::').last}"
+      end
+    end
+  end
+end

--- a/lib/hypertemplate/builder/json.rb
+++ b/lib/hypertemplate/builder/json.rb
@@ -75,7 +75,7 @@ module Hypertemplate
       end
 
       def representation
-        @raw.to_json
+        Yajl::Encoder.encode(@raw)
       end
 
     private

--- a/lib/hypertemplate/builder/json.rb
+++ b/lib/hypertemplate/builder/json.rb
@@ -75,7 +75,7 @@ module Hypertemplate
       end
 
       def representation
-        Yajl::Encoder.encode(@raw)
+        MultiJson.encode(@raw)
       end
 
     private

--- a/lib/hypertemplate/hook/rails.rb
+++ b/lib/hypertemplate/hook/rails.rb
@@ -1,6 +1,12 @@
 require 'hypertemplate' unless defined? ::Hypertemplate
 
 module Hypertemplate
+  class Railtie < Rails::Railtie
+    initializer "hypertemplate.setup_cache" do
+      Hypertemplate::Builder::Base.cache = Rails.cache
+    end
+  end
+
   module RegistryContainer
 
     def hypertemplate_registry


### PR DESCRIPTION
I added a way to cache certain parts of a hypertemplate document. The syntax I have devised:

``` ruby
member(@item) do |member|
  member.cache("item_#{@item.id}") do |member|
    member.values do |val|
      val.slow @item.slow_method
    end
  end
end
```

It's a work in progress: the implementation is coupled to XML & JSON, and there are no tests. Just looking if there's interest in this, and if the approach I've taken is a good one. Any suggestions welcome. I'm using this in production with great results
